### PR TITLE
Fix: Correct element ID for urgent count

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -34,7 +34,7 @@ class HomelabDashboard {
       document.getElementById('totalLogs').textContent = total;
   
       const urgentCount = stats.recentUrgent?.[0]?.count ?? 0;
-      document.getElementById('urgentCount').textContent = urgentCount;
+      document.getElementById('urgentLogs').textContent = urgentCount;
   
       const globalStatus = document.getElementById('globalStatus');
       if (urgentCount > 5) {


### PR DESCRIPTION
The JavaScript code in `public/app.js` was trying to update an element with the ID `urgentCount`. However, the corresponding element in `public/index.html` has the ID `urgentLogs`.

This commit updates `public/app.js` to use the correct ID (`urgentLogs`), resolving the TypeError that occurred when trying to set `textContent` on a null element.